### PR TITLE
Fix targetSDK as it was causing build error

### DIFF
--- a/common.gradle
+++ b/common.gradle
@@ -10,7 +10,7 @@ android {
     compileSdkVersion 30
     defaultConfig {
         minSdkVersion 24
-        targetSdkVersion compileSdkVersion
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
For some reason the targetSDK wasn't picking up the compileSDK value.  Causing the following error when launching on the emulator:

![build-error](https://user-images.githubusercontent.com/73941747/100427140-e7a5fd00-3089-11eb-9322-a870bebd0850.png)

One liner fix.