### PR TITLE
Fixes location of the permission request that was causing the bug

### DIFF
--- a/androidHackathonApp/src/main/java/com/kcc/kmmhackathon/androidHackathonApp/view/MapsFragment.kt
+++ b/androidHackathonApp/src/main/java/com/kcc/kmmhackathon/androidHackathonApp/view/MapsFragment.kt
@@ -26,10 +26,6 @@ class MapsFragment : Fragment() {
     private lateinit var map: GoogleMap
     private val viewModel: MapsViewModel by viewModels()
 
-    override fun onAttach(context: Context) {
-        super.onAttach(context)
-    }
-
     private val callback = OnMapReadyCallback { googleMap ->
         map = googleMap
         requestFineLocationPermission(LOCATION_PERMISSION_REQUEST_CODE)

--- a/androidHackathonApp/src/main/java/com/kcc/kmmhackathon/androidHackathonApp/view/MapsFragment.kt
+++ b/androidHackathonApp/src/main/java/com/kcc/kmmhackathon/androidHackathonApp/view/MapsFragment.kt
@@ -28,18 +28,17 @@ class MapsFragment : Fragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        requestFineLocationPermission(LOCATION_PERMISSION_REQUEST_CODE)
     }
 
     private val callback = OnMapReadyCallback { googleMap ->
         map = googleMap
+        requestFineLocationPermission(LOCATION_PERMISSION_REQUEST_CODE)
     }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-
         return inflater.inflate(R.layout.fragment_maps, container, false)
     }
 


### PR DESCRIPTION
Previously the request permissions was placed in on attach, however that could cause a race condition bug where it was modifying the map before it had been created.

Moving it into the onMapReadyCallback fixes this error.