### PR TITLE
ReadMe update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Currently, a user can: create an account and login and search for meals in their
 ## Prerequisites
 
 ### Android Studio
-Version 4.2 > is required to compile this project. From the latest changes, Arctic Fox (Canary 2, Beta) is required due to using Compose.
+Version 4.3 > is required to compile this project. From the latest changes, Arctic Fox (Canary 2, Beta) is required due to using Compose.
 
 ### Xcode
 For running the iOS app via Xcode and for using the simulator, version 12.1 > is required.
@@ -32,7 +32,7 @@ When picking up a ticket from the `To do` column, please assign yourself and mov
 Tickets in the `Backlog` column are _roughly_ prioritised and have a brief description.
 If moving cards from `Backlog` into `To do` please convert the card to an issue (you can do this by tapping the ... button on the top-right of the card) and add the relevant label (`ios`/`Android`/`kmm`) and ensure the AC's are correct and up to date.
 
-When opening a PR, please link it to the issue you are working on and this will ensure that the card will be automatically moved along to the correct column.
+When opening a PR, please set the Projects option on the right to `Hackathon` and link it to the issue you are working on and this will ensure that the card will be automatically moved along to the correct column.
 
 ### Mock-Server
 We are currently using `json-server` as a mock server to run the project against. 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ We're using Firebse for authentication purposes - for viewing this data and maki
 
 ### Please message the slack channel `ios-bench-hackathon-nov20` if you don't have these and we will send details over if you need access ^ ###
 
+
+### Contributing
+We are using Github projects to keep a track of tickets.
+You can access it from the [`Projects`](https://github.com/theappbusiness/benchHackathonNov20/projects/1) tab in the repo.
+
+Tickets in the `To do` column are prioritised and have ACs associated with them.
+When picking up a ticket from the `To do` column, please assign yourself and move into `In progress`.
+
+Tickets in the `Backlog` column are _roughly_ prioritised and have a brief description.
+If moving cards from `Backlog` into `To do` please convert the card to an issue (you can do this by tapping the ... button on the top-right of the card) and add the relevant label (`ios`/`Android`/`kmm`) and ensure the AC's are correct and up to date.
+
+When opening a PR, please link it to the issue you are working on and this will ensure that the card will be automatically moved along to the correct column.
+
 ### Mock-Server
 We are currently using `json-server` as a mock server to run the project against. 
 This is required to display and post the meal data.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ We're using Firebse for authentication purposes - for viewing this data and maki
 ### Please message the slack channel `ios-bench-hackathon-nov20` if you don't have these and we will send details over if you need access ^ ###
 
 
-### Contributing
+### Tickets and Issues
 We are using Github projects to keep a track of tickets.
 You can access it from the [`Projects`](https://github.com/theappbusiness/benchHackathonNov20/projects/1) tab in the repo.
 


### PR DESCRIPTION
I've updated the ReadMe to include a link to the projects area of the repo and with a bit of chat about the (potential) workflow.

The reason for doing this, is that I think it'll be new to most people to be using Github projects to keep a track of tickets so it's handy to point it out.

But worth mentioning that I haven't used Github projects before, so if any one has suggestions for a different way to work then I'm all ears 👂 😄 
And also that I haven't seen this automation in action, so if what I wrote in the readme turns out to be bollocks then I'll change it 😅 (using this PR as a test)